### PR TITLE
Hotfix: Stabilize tests by replacing sleep() with time mocking (v0.4.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ phpstan.neon
 testbench.yaml
 /docs
 /coverage
+.docker
+.dockerignore

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         "php": "^8.3"
     },
     "suggest": {
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "illuminate/contracts": "^10.48.29||^11.0||^12.0"
     },
     "require-dev": {
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.48.29||^11.0||^12.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0||^6.4.0",
         "larastan/larastan": "^2.9||^3.0",
-        "orchestra/testbench": "^10.0.0||^9.3.0||^8.22.0",
+        "orchestra/testbench": "^10.0.0||^9.3.0||^8.36.0",
         "pestphp/pest": "^2.36||^3.0",
         "pestphp/pest-plugin-arch": "^2.5||^3.0",
         "pestphp/pest-plugin-laravel": "^2.0||^3.0",

--- a/src/CircuitBreaker.php
+++ b/src/CircuitBreaker.php
@@ -134,7 +134,7 @@ class CircuitBreaker implements CircuitBreakerContract
                 $this->transitionToOpen();
                 $this->notify("Circuit breaker opened after {$failures} failures.");
             } elseif ($this->isHalfOpen()) {
-                $this->setKey('last_half_open_attempt', time());
+                $this->setKey('last_half_open_attempt', Carbon::now()->timestamp);
                 $this->cache->increment($this->getKey('half_open_attempts'));
                 $halfOpenAttempts = $this->cache->get($this->getKey('half_open_attempts'), 0);
 
@@ -219,7 +219,7 @@ class CircuitBreaker implements CircuitBreakerContract
     {
         $this->setKey('state', self::STATE_HALF_OPEN);
         $this->setKey('half_open_attempts', 0);
-        $this->setKey('last_half_open_attempt', time());
+        $this->setKey('last_half_open_attempt', Carbon::now()->timestamp);
 
         $this->logger->warning("CircuitBreaker '{$this->name}' transitioned to HALF_OPEN state at {$this->getTimestamp()}.", $this->getStats());
     }

--- a/src/Strategies/TimeWindowStrategy.php
+++ b/src/Strategies/TimeWindowStrategy.php
@@ -58,7 +58,7 @@ class TimeWindowStrategy implements FailureStrategyContract
     public function recordFailure(CacheContract $cache, string $key): int
     {
         // Store failure with timestamp
-        $now = time();
+        $now = Carbon::now()->timestamp;
         $failures = $cache->get($key.':timeline', []);
 
         // If cache data is corrupted (not an array), reset failures
@@ -158,7 +158,7 @@ class TimeWindowStrategy implements FailureStrategyContract
     private function getWaitTime(int $lastHalfOpenAttempt, int $halfOpenAttempts): int
     {
         $halfOpenAttempts = max($halfOpenAttempts, 1);
-        $timeSinceLastAttempt = (time() - $lastHalfOpenAttempt);
+        $timeSinceLastAttempt = (Carbon::now()->timestamp - $lastHalfOpenAttempt);
         $baseDelay = $this->halfOpenDelaySeconds * (2 ** ($halfOpenAttempts - 1));
         $jitter = $baseDelay * (rand(0, 20) / 100); // 0-20% jitter
         $minDelay = $baseDelay + $jitter;
@@ -194,7 +194,7 @@ class TimeWindowStrategy implements FailureStrategyContract
      */
     private function filterOldFailures(array $failures): array
     {
-        $now = time();
+        $now = Carbon::now()->timestamp;
         // Keep only failures within the sliding window
         $recentFailures = array_filter(
             $failures,
@@ -209,6 +209,6 @@ class TimeWindowStrategy implements FailureStrategyContract
      */
     private function isValidTimestamp(mixed $timestamp): bool
     {
-        return is_numeric($timestamp) && $timestamp > 0 && $timestamp <= time() + 1;
+        return is_numeric($timestamp) && $timestamp > 0 && $timestamp <= Carbon::now()->timestamp + 1;
     }
 }

--- a/tests/Adapters/Laravel/CacheAdapterTest.php
+++ b/tests/Adapters/Laravel/CacheAdapterTest.php
@@ -2,8 +2,8 @@
 
 namespace christopheraseidl\CircuitBreaker\Tests\Adapters\Laravel;
 
+use Carbon\Carbon;
 use christopheraseidl\CircuitBreaker\Adapters\Laravel\LaravelCacheAdapter;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 
 beforeEach(function () {

--- a/tests/CircuitBreaker/EdgeCasesTest.php
+++ b/tests/CircuitBreaker/EdgeCasesTest.php
@@ -2,6 +2,7 @@
 
 namespace christopheraseidl\CircuitBreaker\Tests\CircuitBreaker;
 
+use Carbon\Carbon;
 use christopheraseidl\CircuitBreaker\CircuitBreaker;
 use christopheraseidl\CircuitBreaker\Contracts\CacheContract;
 use christopheraseidl\CircuitBreaker\Contracts\LoggerContract;
@@ -91,7 +92,7 @@ it('handles concurrent state changes', function () {
 
     // Simulate another process opening the circuit
     $this->cache->put('circuit_breaker:test:state', 'open');
-    $this->cache->put('circuit_breaker:test:opened_at', time());
+    $this->cache->put('circuit_breaker:test:opened_at', Carbon::now()->timestamp);
 
     // Should respect the state change
     expect($breaker->isOpen())->toBeTrue();

--- a/tests/CircuitBreaker/RecoveryTest.php
+++ b/tests/CircuitBreaker/RecoveryTest.php
@@ -2,6 +2,7 @@
 
 namespace christopheraseidl\CircuitBreaker\Tests\CircuitBreaker;
 
+use Carbon\Carbon;
 use christopheraseidl\CircuitBreaker\CircuitBreaker;
 use christopheraseidl\CircuitBreaker\Tests\Helpers\TestCacheAdapter;
 use christopheraseidl\CircuitBreaker\Tests\Helpers\TestLoggerAdapter;
@@ -31,7 +32,7 @@ it('allows two attempts in half-open state', function () {
     expect($breaker->isOpen())->toBeTrue();
 
     // Wait for recovery timeout
-    sleep(2);
+    Carbon::setTestNow(now()->addSeconds(2));
 
     // Should transition to half-open and allow attempt
     expect($breaker->canAttempt())->toBeTrue();
@@ -60,7 +61,7 @@ it('enforces delay between half-open attempts', function () {
     $breaker->recordFailure();
 
     // Wait for recovery timeout
-    sleep(2);
+    Carbon::setTestNow(now()->addSeconds(2));
 
     // First attempt allowed (transitions to half-open)
     expect($breaker->canAttempt())->toBeTrue();
@@ -72,7 +73,7 @@ it('enforces delay between half-open attempts', function () {
     expect($breaker->canAttempt())->toBeFalse();
 
     // Wait for delay to pass
-    sleep(3);
+    Carbon::setTestNow(now()->addSeconds(3));
 
     // Now should allow attempt
     expect($breaker->canAttempt())->toBeTrue();
@@ -93,7 +94,7 @@ it('tracks half-open attempt count', function () {
     $breaker->recordFailure();
 
     // Wait for recovery timeout
-    sleep(2);
+    Carbon::setTestNow(now()->addSeconds(2));
 
     // Transition to half-open
     expect($breaker->canAttempt())->toBeTrue();
@@ -136,7 +137,7 @@ it('calculates wait time correctly', function () {
     $breaker->recordFailure();
 
     // Wait for recovery timeout
-    sleep(2);
+    Carbon::setTestNow(now()->addSeconds(2));
 
     // First attempt (transitions to half-open)
     expect($breaker->canAttempt())->toBeTrue();
@@ -147,7 +148,7 @@ it('calculates wait time correctly', function () {
     expect($breaker->canAttempt())->toBeFalse();
 
     // Wait to pass the max delay of 1.2 seconds with jitter
-    usleep(1300000); // 1.3 seconds
+    Carbon::setTestNow(now()->addMilliseconds(1300)); // 1.3 seconds
     expect($breaker->canAttempt())->toBeTrue();
 
     // Second failure - base delay should be max 2.4 seconds with jitter and exponential backoff
@@ -155,6 +156,6 @@ it('calculates wait time correctly', function () {
     expect($breaker->canAttempt())->toBeFalse();
 
     // Wait for the exponential delay
-    sleep(3);
+    Carbon::setTestNow(now()->addSeconds(3));
     expect($breaker->canAttempt())->toBeTrue();
 });

--- a/tests/Helpers/TestLoggerAdapter.php
+++ b/tests/Helpers/TestLoggerAdapter.php
@@ -2,6 +2,7 @@
 
 namespace christopheraseidl\CircuitBreaker\Tests\Helpers;
 
+use Carbon\Carbon;
 use christopheraseidl\CircuitBreaker\Contracts\LoggerContract;
 
 /**
@@ -57,7 +58,7 @@ class TestLoggerAdapter implements LoggerContract
             'level' => $level,
             'message' => (string) $message,
             'context' => $context,
-            'timestamp' => time(),
+            'timestamp' => Carbon::now()->timestamp,
         ];
     }
 

--- a/tests/Helpers/TestMailerAdapter.php
+++ b/tests/Helpers/TestMailerAdapter.php
@@ -2,6 +2,7 @@
 
 namespace christopheraseidl\CircuitBreaker\Tests\Helpers;
 
+use Carbon\Carbon;
 use christopheraseidl\CircuitBreaker\Contracts\MailerContract;
 
 /**
@@ -26,7 +27,7 @@ class TestMailerAdapter implements MailerContract
             'to' => $to,
             'subject' => $subject,
             'message' => $message,
-            'timestamp' => time(),
+            'timestamp' => Carbon::now()->timestamp,
         ];
     }
 

--- a/tests/Helpers/TestNotifierAdapter.php
+++ b/tests/Helpers/TestNotifierAdapter.php
@@ -2,6 +2,7 @@
 
 namespace christopheraseidl\CircuitBreaker\Tests\Helpers;
 
+use Carbon\Carbon;
 use christopheraseidl\CircuitBreaker\Contracts\NotifierContract;
 
 /**
@@ -16,7 +17,7 @@ class TestNotifierAdapter implements NotifierContract
         $this->notifications[] = [
             'message' => $message,
             'context' => $context,
-            'timestamp' => time(),
+            'timestamp' => Carbon::now()->timestamp,
         ];
     }
 

--- a/tests/Strategies/TimeWindowStrategyTest.php
+++ b/tests/Strategies/TimeWindowStrategyTest.php
@@ -2,6 +2,7 @@
 
 namespace christopheraseidl\CircuitBreaker\Tests\Strategies;
 
+use Carbon\Carbon;
 use christopheraseidl\CircuitBreaker\Strategies\TimeWindowStrategy;
 use christopheraseidl\CircuitBreaker\Support\Config;
 use christopheraseidl\CircuitBreaker\Tests\Helpers\TestCacheAdapter;
@@ -35,7 +36,7 @@ it('expires old failures outside window', function () {
     expect($strategy->getCurrentFailureCount($this->cache, 'test-key'))->toBe(1);
 
     // Wait for window to expire
-    sleep(3);
+    Carbon::setTestNow(now()->addSeconds(3));
 
     // Old failure should be expired
     expect($strategy->getCurrentFailureCount($this->cache, 'test-key'))->toBe(0);
@@ -66,14 +67,14 @@ it('determines when to transition to half-open', function () {
     $strategy = new TimeWindowStrategy(['recovery_timeout_seconds' => 2]); // 2 seconds for testing
 
     // Set opened_at timestamp
-    $openedAt = time();
+    $openedAt = Carbon::now()->timestamp;
     $this->cache->put('test-key', $openedAt);
 
     // Should not transition immediately
     expect($strategy->shouldHalfOpenFromOpen($this->cache, 'test-key'))->toBeFalse();
 
     // Wait for recovery timeout
-    sleep(3);
+    Carbon::setTestNow(now()->addSeconds(3));
 
     // Should transition after timeout
     expect($strategy->shouldHalfOpenFromOpen($this->cache, 'test-key'))->toBeTrue();
@@ -148,11 +149,11 @@ it('accepts default configuration', function () {
     expect($strategy->shouldOpenFromClosed($this->cache, 'test-key'))->toBeTrue();
 
     // Test recovery timeout (1 second)
-    $openedAt = time();
+    $openedAt = Carbon::now()->timestamp;
     $this->cache->put('test-key', $openedAt);
     expect($strategy->shouldHalfOpenFromOpen($this->cache, 'test-key'))->toBeFalse();
 
-    sleep(1);
+    Carbon::setTestNow(now()->addSeconds(1));
 
     expect($strategy->shouldHalfOpenFromOpen($this->cache, 'test-key'))->toBeTrue();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace christopheraseidl\CircuitBreaker\Tests;
 
 use christopheraseidl\CircuitBreaker\Laravel\CircuitBreakerServiceProvider;
-use christopheraseidl\CircuitBreaker\Support\Config;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -18,10 +17,5 @@ class TestCase extends Orchestra
         return [
             CircuitBreakerServiceProvider::class,
         ];
-    }
-
-    public function getEnvironmentSetUp($app)
-    {
-        Config::set('database.default', 'testing');
     }
 }


### PR DESCRIPTION
## Changes
- Replaces `sleep()` with use of Carbon\Carbon in tests.
- Additionally bumps Laravel 10 to ^10.48.29 and Testbench 8 to ^8.36.0.

## Impact
- Fixes intermittent timeouts in tests.
- Reduces test suite runtime from ~15s to ~1s.
- Fixes errors when installing composer dependencies with PHP 8.4 and prefer-lowest flag.
- Required for stable release v0.4.2.